### PR TITLE
fix: add ParseToken func to the jwt middleware

### DIFF
--- a/internal/http/handler/home.go
+++ b/internal/http/handler/home.go
@@ -8,7 +8,7 @@ import (
 	"github.com/1995parham-teaching/fandogh/internal/http/request"
 	"github.com/1995parham-teaching/fandogh/internal/model"
 	"github.com/1995parham-teaching/fandogh/internal/store/home"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo/v4"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -42,14 +42,9 @@ func (h Home) New(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	token, ok := c.Get(common.UserContextKey).(*jwt.Token)
+	mc, ok := c.Get(common.UserContextKey).(jwt.MapClaims)
 	if !ok {
-		return echo.NewHTTPError(http.StatusUnauthorized)
-	}
-
-	claims, ok := token.Claims.(*jwt.StandardClaims)
-	if !ok {
-		return echo.NewHTTPError(http.StatusUnauthorized)
+		return echo.NewHTTPError(http.StatusBadRequest, "user claims not found")
 	}
 
 	var bed model.Bed
@@ -104,7 +99,7 @@ func (h Home) New(c echo.Context) error {
 
 	m := model.Home{
 		ID:              "",
-		Owner:           claims.Subject,
+		Owner:           mc["sub"].(string),
 		Title:           rq.Title,
 		Location:        rq.Location,
 		Description:     rq.Description,


### PR DESCRIPTION
The jwt middleware did not work properly because the parse token method was not included. 